### PR TITLE
add time dependecy on sqlite feature

### DIFF
--- a/crates/sqlx-migrate/Cargo.toml
+++ b/crates/sqlx-migrate/Cargo.toml
@@ -68,7 +68,7 @@ cli = [
     "dep:dotenvy",
 ]
 
-sqlite = ["sqlx/sqlite"]
+sqlite = ["sqlx/sqlite", "dep:time"]
 postgres = ["sqlx/postgres"]
 
 # Used for documentation generation purposes only.


### PR DESCRIPTION
The `time` crate was not being installed with the `sqlite` feature enabled, even though it is needed.
It may have been overlooked as it is a dependency of the `cli` package and therefore it is most-often included.