### PR TITLE
Replace `atty` with `IsTerminal`

### DIFF
--- a/crates/sqlx-migrate/Cargo.toml
+++ b/crates/sqlx-migrate/Cargo.toml
@@ -35,7 +35,6 @@ clap = { version = "4.3.0", features = ["derive"], optional = true }
 tracing-subscriber = { version = "0.3.3", features = [
     "env-filter",
 ], optional = true }
-atty = { version = "0.2.14", optional = true }
 tokio = { version = "1.14.0", features = ["rt"], optional = true }
 comfy-table = { version = "7.0.1", optional = true }
 time = { version = "0.3", optional = true, features = ["formatting"] }
@@ -63,7 +62,6 @@ cli = [
     "dep:time",
     "dep:clap",
     "dep:tracing-subscriber",
-    "dep:atty",
     "dep:tokio",
     "dep:comfy-table",
     "dep:regex",

--- a/crates/sqlx-migrate/src/cli.rs
+++ b/crates/sqlx-migrate/src/cli.rs
@@ -11,7 +11,14 @@ use comfy_table::{Cell, CellAlignment, ContentArrangement, Table};
 use filetime::FileTime;
 use regex::Regex;
 use sqlx::{ConnectOptions, Database, Executor};
-use std::{fs, io, path::Path, process, str::FromStr, time::Duration};
+use std::{
+    fs,
+    io::{self, stdout, IsTerminal},
+    path::Path,
+    process,
+    str::FromStr,
+    time::Duration,
+};
 use time::{format_description, OffsetDateTime};
 use tracing_subscriber::{
     fmt::format::FmtSpan, prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt,
@@ -724,5 +731,5 @@ fn colors(matches: &Migrate) -> bool {
         return false;
     }
 
-    atty::is(atty::Stream::Stdout)
+    stdout().is_terminal()
 }


### PR DESCRIPTION
Resolves `atty` vulnerability reported at
https://github.com/advisories/GHSA-g98v-hv3f-hcfr.

Since Rust 1.70 the `IsTerminal` trait is stable and implemented by `std::io::Stdout`: https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#isterminal